### PR TITLE
Update help text to reflect new nugget id workings

### DIFF
--- a/src/main/js/screens/app/screens/nuggetCsv/nuggetCsv.js
+++ b/src/main/js/screens/app/screens/nuggetCsv/nuggetCsv.js
@@ -49,10 +49,10 @@ class nuggetCsv extends React.Component {
             på struktur uppfyllas. Exempel på filformat följer: <br />
             <code>
               # Headers <br />
-              Id, Description, Title, Type, Lessons, Swedish, English, JpRead, JpWrite, Hidden <br />
+              Description, Title, Type, Lessons, Swedish, English, JpRead, JpWrite, Hidden <br />
 
               # Body <br />
-              1,"Test nugget","Test title","Test type","Test lesson","svenska","english","Japanese reading","Japanese writing",false <br />
+              "Test nugget","Test title","Test type","Test lesson","svenska","english","Japanese reading","Japanese writing",false <br />
             </code>
             De namn som ges på Title, Type och Lesson måste, respektive, stämma överens
             titeln på en existerande bok, en existerande ordtyp och en existerande lektion.


### PR DESCRIPTION
This was the only instance where nugget id was referenced that I found. May have missed something?