### PR TITLE
Change bootstrap version from latest to 3.3.7

### DIFF
--- a/src/main/resources/static/html/webpack_index.html
+++ b/src/main/resources/static/html/webpack_index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>gakusei-admin</title>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
     <link rel="icon" type="image/png" href="/icons/favicon-32x32.png" sizes="32x32">
 </head>
 <body>


### PR DESCRIPTION
The latest bootstrap version is breaking the page, instead use version 3.3.7 which works. 